### PR TITLE
Adds support for OpenJDK which prints versions differently

### DIFF
--- a/chaffee.zsh-theme
+++ b/chaffee.zsh-theme
@@ -19,7 +19,7 @@ function java_prompt_prefix() {
 
 function java_prompt_info() {
   if command -v java >/dev/null 2>&1; then
-    echo "$ZSH_THEME_JAVA_PROMPT_PREFIX$(java -version 2>&1 | grep 'java version' | awk '{print $3}' | tr -d \")$ZSH_THEME_JAVA_PROMPT_SUFFIX"
+    echo "$ZSH_THEME_JAVA_PROMPT_PREFIX$(java -version 2>&1 | grep -i -e 'java version' -e 'openjdk version' | awk '{print $3}' | tr -d \")$ZSH_THEME_JAVA_PROMPT_SUFFIX"
   fi
 }
 


### PR DESCRIPTION
I noticed that OpenJDK prints version information differently, so this updated grep should catch either. I tested with JDK 8, 11, 13, and 15 for OpenJDK and Java 8 and 11 for Oracle.